### PR TITLE
Use the built-in GitHub actions token (rather than a separate secret).

### DIFF
--- a/.github/workflows/crunch42.yml
+++ b/.github/workflows/crunch42.yml
@@ -58,4 +58,4 @@ jobs:
           # Upload results to Github code scanning
           upload-to-code-scanning: true
           # Github token for uploading the results
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

Saves someone from having to generate a personal GH token.

This secret looks like it's already used by the GitHub UI's 42Crunch workflow template (e.g.
https://github.com/Julian/audit-integration/new/main?filename=.github%2Fworkflows%2Fcrunch42.yml&workflow_template=crunch42 and seems to work correctly in "real life" when used on my fork: https://github.com/Julian/audit-integration/security/code-scanning